### PR TITLE
Treat all dimensions as spatial during inference

### DIFF
--- a/cellulus/models/unet.py
+++ b/cellulus/models/unet.py
@@ -3,7 +3,6 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 from funlib.learn.torch.models import UNet
-from tqdm import tqdm
 
 
 class UNetModel(nn.Module):  # type: ignore
@@ -79,7 +78,7 @@ class UNetModel(nn.Module):  # type: ignore
             return self.head_forward(h)
         elif self.mode == "infer":
             embeddings = []
-            for sample in tqdm(range(raw.shape[0])):
+            for sample in range(raw.shape[0]):
                 raw_sample = raw[sample : sample + 1, ...]
                 predictions = []
                 for val in [0.5, 1.0]:

--- a/cellulus/predict.py
+++ b/cellulus/predict.py
@@ -11,8 +11,6 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
     dataset_config = inference_config.dataset_config
     dataset_meta_data = DatasetMetaData.from_dataset_config(dataset_config)
 
-    voxel_size = gp.Coordinate((1,) * dataset_meta_data.num_spatial_dims)
-
     # set device
     device = torch.device(inference_config.device)
 
@@ -36,10 +34,24 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
         ).shape
     )
 
-    input_size = gp.Coordinate(input_shape[2:]) * voxel_size
-    output_size = gp.Coordinate(output_shape[2:]) * voxel_size
+    # treat all dimensions as spatial, with a voxel size of 1
+    voxel_size = (1,) * dataset_meta_data.num_dims
+    raw_spec = gp.ArraySpec(voxel_size=voxel_size, interpolatable=True)
 
-    context = (input_size - output_size) / 2
+    input_size = gp.Coordinate(input_shape) * gp.Coordinate(voxel_size)
+    output_size = gp.Coordinate(output_shape) * gp.Coordinate(voxel_size)
+    diff_size = input_size - output_size
+
+    if dataset_meta_data.num_spatial_dims == 2:
+        context = (0, 0, diff_size[2] // 2, diff_size[3] // 2)
+    elif dataset_meta_data.num_spatial_dims == 3:
+        context = (
+            0,
+            0,
+            diff_size[2] // 2,
+            diff_size[3] // 2,
+            diff_size[4] // 2,
+        )  # type: ignore
 
     raw = gp.ArrayKey("RAW")
     prediction = gp.ArrayKey("PREDICT")
@@ -52,7 +64,7 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
         model,
         inputs={"raw": raw},
         outputs={0: prediction},
-        array_specs={prediction: gp.ArraySpec(voxel_size=voxel_size)},
+        array_specs={prediction: raw_spec},
     )
 
     # prepare the zarr dataset to write to
@@ -70,14 +82,14 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
     ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
         -dataset_meta_data.num_spatial_dims :
     ]
-    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
-    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims
 
+    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_dims
+    ds.attrs["offset"] = (0,) * dataset_meta_data.num_dims
     pipeline = (
         gp.ZarrSource(
             dataset_config.container_path,
             {raw: dataset_config.dataset_name},
-            {raw: gp.ArraySpec(voxel_size=voxel_size)},
+            {raw: gp.ArraySpec(voxel_size=voxel_size, interpolatable=True)},
         )
         + gp.Pad(raw, context)
         + predict

--- a/cellulus/predict.py
+++ b/cellulus/predict.py
@@ -79,12 +79,6 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
         dtype=float,
     )
 
-    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
-        -dataset_meta_data.num_spatial_dims :
-    ]
-
-    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_dims
-    ds.attrs["offset"] = (0,) * dataset_meta_data.num_dims
     pipeline = (
         gp.ZarrSource(
             dataset_config.container_path,
@@ -105,3 +99,10 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
     # request to pipeline for ROI of whole image/volume
     with gp.build(pipeline):
         pipeline.request_batch(gp.BatchRequest())
+
+    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
+        -dataset_meta_data.num_spatial_dims :
+    ]
+
+    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
+    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims


### PR DESCRIPTION
- All dimensions (B, C, Z, Y, X) are treated as spatial in `predict.py`. This was done since, otherwise if only the spatial dimensions are considered, the scan request picks up all the samples in one go, which leads to an out of memory error,e specially while dealing with volumes.
- The `offset` and `resolution` are correctly assigned once the dataset is written (i.e. after the pipeline is built) by moving the respective lines to the end of `predict.py` [here](https://github.com/funkelab/cellulus/blob/9953d8da97498ff2dd6215ce58715ba427be1112/cellulus/predict.py#L103).