### PR TITLE
Update post processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install -e .
 
 ### Getting Started
 
-Try out `2D Example` available **[here](https://funkelab.github.io/cellulus)**. 
+Try out the `2D Example` available **[here](https://funkelab.github.io/cellulus)**. 
 
 ### Citation
 

--- a/cellulus/configs/__init__.py
+++ b/cellulus/configs/__init__.py
@@ -1,4 +1,4 @@
 from .dataset_config import DatasetConfig
 from .experiment_config import ExperimentConfig
 
-__all__ = ["ExperimentConfig", "DatasetConfig"]
+__all__ = ["DatasetConfig", "ExperimentConfig"]

--- a/cellulus/configs/dataset_config.py
+++ b/cellulus/configs/dataset_config.py
@@ -21,8 +21,16 @@ class DatasetConfig:
 
         secondary_dataset_name:
 
-            The name of the dataset containing the data which needs processing.
+            The name of the secondary dataset containing the data which needs
+            processing.
 
+        'dataset_name' and 'secondary_dataset_name' can be thought of as the
+        output and input to a certain task, respectively.
+        For example, during segmentation, 'dataset_name' would refer to the output
+        segmentation masks and 'secondary_dataset_name' would refer to the input
+        predicted embeddings.
+        During evaluation, 'dataset_name' would refer to the ground truth masks
+        and 'secondary_dataset_name' would refer to the input segmentation masks.
 
     """
 

--- a/cellulus/configs/dataset_config.py
+++ b/cellulus/configs/dataset_config.py
@@ -8,7 +8,8 @@ from attrs.validators import instance_of, optional
 class DatasetConfig:
     """Dataset configuration.
 
-    Parameters:
+    Parameters
+    ----------
 
         container_path:
 
@@ -16,7 +17,7 @@ class DatasetConfig:
 
         dataset_name:
 
-            The name of the dataset containing raw data in the container.
+            The name of the dataset containing the raw data in the container.
 
         secondary_dataset_name:
 

--- a/cellulus/configs/experiment_config.py
+++ b/cellulus/configs/experiment_config.py
@@ -13,13 +13,14 @@ from .utils import to_config
 class ExperimentConfig:
     """Top-level config for an experiment (containing training and prediction).
 
-    Parameters:
+    Parameters
+    ----------
 
         experiment_name: (default = 'YYYY-MM-DD')
 
             A unique name for the experiment.
 
-        object_size: (default = 26.0)
+        object_size: (default = 26)
 
             A rough estimate of the size of objects in the image, given in
             world units. The "patch size" of the network will be chosen based
@@ -42,7 +43,7 @@ class ExperimentConfig:
     experiment_name: str = attrs.field(
         default=datetime.today().strftime("%Y-%m-%d"), validator=instance_of(str)
     )
-    object_size: float = attrs.field(default=26.0, validator=instance_of(float))
+    object_size: int = attrs.field(default=26, validator=instance_of(int))
 
     train_config: TrainConfig = attrs.field(
         default=None, converter=to_config(TrainConfig)

--- a/cellulus/configs/experiment_config.py
+++ b/cellulus/configs/experiment_config.py
@@ -20,15 +20,21 @@ class ExperimentConfig:
 
             A unique name for the experiment.
 
-        object_size: (default = 30.0)
+        object_size: (default = 30)
 
             A rough estimate of the size of objects in the image, given in
             world units. The "patch size" of the network will be chosen based
             on this estimate.
 
+        normalization_factor: (default = None)
+
+            The factor to use, for dividing the raw image pixel intensities.
+            If 'None', a factor is chosen based on the dtype of the array .
+            (e.g., np.uint8 would result in a factor of 1.0/255).
+
         model_config:
 
-            The model configuration.
+            Configuration object for the model.
 
         train_config:
 
@@ -43,7 +49,10 @@ class ExperimentConfig:
     experiment_name: str = attrs.field(
         default=datetime.today().strftime("%Y-%m-%d"), validator=instance_of(str)
     )
-    object_size: float = attrs.field(default=30.0, validator=instance_of(float))
+    normalization_factor: float = attrs.field(
+        default=None, validator=attrs.validators.optional(instance_of(float))
+    )
+    object_size: int = attrs.field(default=30, validator=instance_of(int))
 
     train_config: TrainConfig = attrs.field(
         default=None, converter=to_config(TrainConfig)

--- a/cellulus/configs/experiment_config.py
+++ b/cellulus/configs/experiment_config.py
@@ -20,7 +20,7 @@ class ExperimentConfig:
 
             A unique name for the experiment.
 
-        object_size: (default = 26)
+        object_size: (default = 30.0)
 
             A rough estimate of the size of objects in the image, given in
             world units. The "patch size" of the network will be chosen based
@@ -43,7 +43,7 @@ class ExperimentConfig:
     experiment_name: str = attrs.field(
         default=datetime.today().strftime("%Y-%m-%d"), validator=instance_of(str)
     )
-    object_size: int = attrs.field(default=26, validator=instance_of(int))
+    object_size: float = attrs.field(default=30.0, validator=instance_of(float))
 
     train_config: TrainConfig = attrs.field(
         default=None, converter=to_config(TrainConfig)

--- a/cellulus/configs/inference_config.py
+++ b/cellulus/configs/inference_config.py
@@ -28,7 +28,7 @@ class InferenceConfig:
 
         post_processed_dataset_config:
 
-            Configuration object produced by postprocess.py.
+            Configuration object produced by post_process.py.
 
         evaluation_dataset_config:
 
@@ -49,7 +49,7 @@ class InferenceConfig:
 
         bandwidth (default = None):
 
-            Band-width used to perform mean-shift clustering on the predicted
+            Bandwidth used to perform mean-shift clustering on the predicted
             embeddings.
 
         threshold (default = None):
@@ -75,6 +75,14 @@ class InferenceConfig:
         num_bandwidths (default = 1):
 
             Number of bandwidths to obtain segmentations for.
+
+        reduction_probability (default = 0.1):
+
+            If set to less than 1.0, this fraction of available pixels are used
+            to determine the clusters (fitting stage) while performing
+            meanshift clustering.
+            Once clusters are available, they are used to predict the cluster assignment
+            of the remaining pixels (prediction stage).
 
         min_size (default = None):
 
@@ -132,15 +140,13 @@ class InferenceConfig:
         default="meanshift", validator=in_(["meanshift", "greedy"])
     )
     bandwidth = attrs.field(
-        default=None, validator=attrs.validators.optional(instance_of(int))
+        default=None, validator=attrs.validators.optional(instance_of(float))
     )
     num_bandwidths = attrs.field(default=1, validator=instance_of(int))
     reduction_probability = attrs.field(default=0.1, validator=instance_of(float))
     min_size = attrs.field(
         default=None, validator=attrs.validators.optional(instance_of(int))
     )
-    post_processing = attrs.field(
-        default="morphological", validator=in_(["morphological", "intensity"])
-    )
+    post_processing = attrs.field(default="cell", validator=in_(["cell", "nucleus"]))
     grow_distance = attrs.field(default=3, validator=instance_of(int))
     shrink_distance = attrs.field(default=6, validator=instance_of(int))

--- a/cellulus/configs/inference_config.py
+++ b/cellulus/configs/inference_config.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import attrs
-from attrs.validators import instance_of
+from attrs.validators import in_, instance_of
 
 from .dataset_config import DatasetConfig
 from .utils import to_config
@@ -11,7 +11,8 @@ from .utils import to_config
 class InferenceConfig:
     """Inference configuration.
 
-    Parameters:
+    Parameters
+    ----------
 
         dataset_config:
 
@@ -33,44 +34,71 @@ class InferenceConfig:
 
             Configuration object for the ground truth masks.
 
-        crop_size:
+        crop_size (default = [252, 252]):
 
             ROI used by the scan node in gunpowder.
 
-        p_salt_pepper:
+        p_salt_pepper (default = 0.01):
 
             Fraction of pixels that will have salt-pepper noise.
 
-        num_infer_iterations:
+        num_infer_iterations (default = 16):
 
             Number of times the salt-peper noise is added to the raw image.
+            This is used to infer the foreground and background in the raw image.
 
-        bandwidth:
+        bandwidth (default = None):
 
             Band-width used to perform mean-shift clustering on the predicted
             embeddings.
 
-        threshold:
+        threshold (default = None):
 
             Threshold to use for binary partitioning into foreground and background
             pixel regions. If None, this is figured out automatically by performing
             Otsu Thresholding on the last channel of the predicted embeddings.
 
-        reduction_probability:
+        min_size (default = None):
 
-
-        min_size:
-
-            Ignore objects which are smaller than min_size number of pixels.
+            Ignore objects which are smaller than `min_size` number of pixels.
 
         device (default = 'cuda:0'):
 
             The device to infer on.
             Set to 'cpu' to infer without GPU.
 
+        clustering (default = 'meanshift'):
+
+            How to cluster the embeddings?
+            Can be one of 'meanshift' or 'greedy'.
+
         num_bandwidths (default = 1):
 
             Number of bandwidths to obtain segmentations for.
+
+        min_size (default = None):
+
+            Objects below `min_size` pixels will be removed.
+
+        post_processing (default= 'morphological'):
+
+            Can be one of 'morphological' or 'intensity' operations.
+            If 'morphological', the individual detections grow and shrink by
+            'grow_distance' and 'shrink_distance' number of pixels.
+
+            If 'intensity', each detection is partitioned based on a binary intensity
+            threshold calculated automatically from the raw image data.
+            By default, the channel `0` in the raw image is used for
+            intensity thresholding.
+
+        grow_distance (default = 3):
+
+            Only used if post_processing (see above) is equal to 'morphological'.
+
+        shrink_distance (default = 6):
+
+            Only used if post_processing (see above) is equal to
+            'morphological'.
 
     """
 
@@ -100,6 +128,9 @@ class InferenceConfig:
     threshold = attrs.field(
         default=None, validator=attrs.validators.optional(instance_of(float))
     )
+    clustering = attrs.field(
+        default="meanshift", validator=in_(["meanshift", "greedy"])
+    )
     bandwidth = attrs.field(
         default=None, validator=attrs.validators.optional(instance_of(int))
     )
@@ -107,6 +138,9 @@ class InferenceConfig:
     reduction_probability = attrs.field(default=0.1, validator=instance_of(float))
     min_size = attrs.field(
         default=None, validator=attrs.validators.optional(instance_of(int))
+    )
+    post_processing = attrs.field(
+        default="morphological", validator=in_(["morphological", "intensity"])
     )
     grow_distance = attrs.field(default=3, validator=instance_of(int))
     shrink_distance = attrs.field(default=6, validator=instance_of(int))

--- a/cellulus/configs/model_config.py
+++ b/cellulus/configs/model_config.py
@@ -9,9 +9,10 @@ from .utils import to_path
 
 @attrs.define
 class ModelConfig:
-    """Model configuration.
+    """Model Configuration.
 
-    Parameters:
+    Parameters
+    ----------
 
         num_fmaps:
 
@@ -22,27 +23,27 @@ class ModelConfig:
             The factor by which to increase the number of feature maps between
             levels of the U-Net.
 
-        features_in_last_layer (optional, default = 64):
+        features_in_last_layer (default = 64):
 
             The number of feature channels in the last layer of the U-Net
 
-        downsampling_factors:
+        downsampling_factors (default = [[2,2]]):
 
             A list of downsampling factors, each given per dimension (e.g.,
             [[2,2], [3,3]] would correspond to two downsample layers, one with
             an isotropic factor of 2, and another one with 3). This parameter
             will also determine the number of levels in the U-Net.
 
-        checkpoint (optional, default ``None``):
+        checkpoint (default = None):
 
             A path to a checkpoint of the network. Needs to be set for networks
             that are used for prediction. If set during training, the
             checkpoint will be used to resume training, otherwise the network
             will be trained from scratch.
 
-        initialize (default: True)
+        initialize (default = True)
 
-            If True, initialize the model weights with Kaiming Normal
+            If True, initialize the model weights with Kaiming Normal.
 
     """
 

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -51,11 +51,15 @@ class TrainConfig:
 
             Neighborhood radius to extract patches from.
 
-        save_model_every (default = 1e3):
+        save_model_every (default = 1000):
 
             The model weights are saved every few iterations.
 
-        save_snapshot_every (default = 1e3):
+        save_best_model_every (default = 100):
+
+            The best loss is evaluated every few iterations.
+
+        save_snapshot_every (default = 1000):
 
             The zarr snapshot is saved every few iterations.
 
@@ -112,6 +116,7 @@ class TrainConfig:
     regularizer_weight: float = attrs.field(default=1e-5, validator=instance_of(float))
     reduce_mean: bool = attrs.field(default=True, validator=instance_of(bool))
     save_model_every: int = attrs.field(default=1_000, validator=instance_of(int))
+    save_best_model_every: int = attrs.field(default=100, validator=instance_of(int))
     save_snapshot_every: int = attrs.field(default=1_000, validator=instance_of(int))
     num_workers: int = attrs.field(default=8, validator=instance_of(int))
     elastic_deform: bool = attrs.field(default=False, validator=instance_of(bool))

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -117,7 +117,6 @@ class TrainConfig:
     kappa: float = attrs.field(default=10.0, validator=instance_of(float))
     temperature: float = attrs.field(default=10.0, validator=instance_of(float))
     regularizer_weight: float = attrs.field(default=1e-5, validator=instance_of(float))
-    reduce_mean: bool = attrs.field(default=True, validator=instance_of(bool))
     save_model_every: int = attrs.field(default=1_000, validator=instance_of(int))
     save_best_model_every: int = attrs.field(default=100, validator=instance_of(int))
     save_snapshot_every: int = attrs.field(default=1_000, validator=instance_of(int))

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -63,16 +63,20 @@ class TrainConfig:
 
             The number of sub-processes to use for data-loading.
 
+        elastic_deform (default = False):
+
+            If set to True, the data is elastically deformed in order to increase training samples.
+
         control_point_spacing (default = 64):
 
             The distance in pixels between control points used for elastic
-            deformation of the raw data during training.
+            deformation of the raw data during training. Only used if `elastic_deform` is set to True.
 
         control_point_jitter (default = 2.0):
 
             How much to jitter the control points for elastic deformation
             of the raw data during training, given as the standard deviation of
-            a normal distribution with zero mean.
+            a normal distribution with zero mean. Only used if `elastic_deform` is set to True.
 
         train_data_config:
 
@@ -110,7 +114,7 @@ class TrainConfig:
     save_model_every: int = attrs.field(default=1_000, validator=instance_of(int))
     save_snapshot_every: int = attrs.field(default=1_000, validator=instance_of(int))
     num_workers: int = attrs.field(default=8, validator=instance_of(int))
-
+    elastic_deform: bool = attrs.field(default=False, validator=instance_of(bool))
     control_point_spacing: int = attrs.field(default=64, validator=instance_of(int))
     control_point_jitter: float = attrs.field(default=2.0, validator=instance_of(float))
     device: str = attrs.field(default="cuda:0", validator=instance_of(str))

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -11,18 +11,19 @@ from .utils import to_config
 class TrainConfig:
     """Train configuration.
 
-    Parameters:
+    Parameters
+    ----------
 
-        crop_size:
+        crop_size (default = [252, 252]):
 
             The size of the crops - specified as a list of number of pixels -
             extracted from the raw images, used during training.
 
-        batch_size:
+        batch_size (default = 8):
 
             The number of samples to use per batch.
 
-        max_iterations:
+        max_iterations (default = 100000):
 
             The maximum number of iterations to train for.
 

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -67,20 +67,23 @@ class TrainConfig:
 
             The number of sub-processes to use for data-loading.
 
-        elastic_deform (default = False):
+        elastic_deform (default = True):
 
-            If set to True, the data is elastically deformed in order to increase training samples.
+            If set to True, the data is elastically deformed
+            in order to increase training samples.
 
         control_point_spacing (default = 64):
 
             The distance in pixels between control points used for elastic
-            deformation of the raw data during training. Only used if `elastic_deform` is set to True.
+            deformation of the raw data during training.
+            Only used if `elastic_deform` is set to True.
 
         control_point_jitter (default = 2.0):
 
             How much to jitter the control points for elastic deformation
             of the raw data during training, given as the standard deviation of
-            a normal distribution with zero mean. Only used if `elastic_deform` is set to True.
+            a normal distribution with zero mean.
+            Only used if `elastic_deform` is set to True.
 
         train_data_config:
 

--- a/cellulus/configs/train_config.py
+++ b/cellulus/configs/train_config.py
@@ -122,7 +122,7 @@ class TrainConfig:
     save_best_model_every: int = attrs.field(default=100, validator=instance_of(int))
     save_snapshot_every: int = attrs.field(default=1_000, validator=instance_of(int))
     num_workers: int = attrs.field(default=8, validator=instance_of(int))
-    elastic_deform: bool = attrs.field(default=False, validator=instance_of(bool))
+    elastic_deform: bool = attrs.field(default=True, validator=instance_of(bool))
     control_point_spacing: int = attrs.field(default=64, validator=instance_of(int))
     control_point_jitter: float = attrs.field(default=2.0, validator=instance_of(float))
     device: str = attrs.field(default="cuda:0", validator=instance_of(str))

--- a/cellulus/criterions/__init__.py
+++ b/cellulus/criterions/__init__.py
@@ -5,17 +5,13 @@ def get_loss(
     temperature,
     regularizer_weight,
     density,
-    kappa,
     num_spatial_dims,
-    reduce_mean,
     device,
 ):
     return OCELoss(
         temperature,
         regularizer_weight,
         density,
-        kappa,
         num_spatial_dims,
-        reduce_mean,
         device,
     )

--- a/cellulus/criterions/oce_loss.py
+++ b/cellulus/criterions/oce_loss.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 import torch.nn as nn
 
@@ -9,9 +8,7 @@ class OCELoss(nn.Module):  # type: ignore
         temperature: float,
         regularization_weight: float,
         density: float,
-        kappa: float,
         num_spatial_dims: int,
-        reduce_mean: bool,
         device: torch.device,
     ):
         """Class definition for loss.
@@ -30,16 +27,8 @@ class OCELoss(nn.Module):  # type: ignore
                 Determines the fraction of patches to sample per crop,
                 during training.
 
-            kappa:
-                Neighborhood radius to extract patches from.
-
             num_spatial_dims:
                 Should be equal to 2 for 2D and 3 for 3D.
-
-            reduce_mean:
-                Should be set to True if the loss should be averaged over all
-                pixels, and set to False, if the sum of the loss over all pixels
-                is expected.
 
             device:
                 The device to train on.
@@ -50,131 +39,25 @@ class OCELoss(nn.Module):  # type: ignore
         self.temperature = temperature
         self.regularization_weight = regularization_weight
         self.density = density
-        self.kappa = kappa
         self.num_spatial_dims = num_spatial_dims
-        self.reduce_mean = reduce_mean
         self.device = device
 
-    def distance_function(self, e0, e1):
-        diff = e0 - e1
-        return diff.norm(2, dim=-1)
+    @staticmethod
+    def distance_function(embedding_0, embedding_1):
+        difference = embedding_0 - embedding_1
+        return difference.norm(2, dim=-1)
 
-    def nonlinearity(self, distance):
+    def non_linearity(self, distance):
         return 1 - (-distance.pow(2) / self.temperature).exp()
 
-    def forward(self, prediction):
-        if self.num_spatial_dims == 2:
-            b, c, h, w = prediction.shape
-
-            h_ = h - 2 * self.kappa  # unbiased height
-            w_ = w - 2 * self.kappa  # unbiased width
-
-            num_anchors = int(self.density * h_ * w_)
-            anchor_coordinates_y = np.random.randint(
-                self.kappa, h - self.kappa, num_anchors
-            )
-            anchor_coordinates_x = np.random.randint(
-                self.kappa, w - self.kappa, num_anchors
-            )
-            anchor_coordinates = np.stack(
-                (anchor_coordinates_x, anchor_coordinates_y), axis=1
-            )  # N x 2
-        elif self.num_spatial_dims == 3:
-            b, c, d, h, w = prediction.shape
-
-            d_ = d - 2 * self.kappa  # unbiased depth
-            h_ = h - 2 * self.kappa  # unbiased height
-            w_ = w - 2 * self.kappa  # unbiased width
-
-            num_anchors = int(self.density * d_ * h_ * w_)
-            anchor_coordinates_z = np.random.randint(
-                self.kappa, d - self.kappa, num_anchors
-            )
-            anchor_coordinates_y = np.random.randint(
-                self.kappa, h - self.kappa, num_anchors
-            )
-            anchor_coordinates_x = np.random.randint(
-                self.kappa, w - self.kappa, num_anchors
-            )
-            anchor_coordinates = np.stack(
-                (anchor_coordinates_x, anchor_coordinates_y, anchor_coordinates_z),
-                axis=1,
-            )  # N x 3
-        num_references = int(self.density * np.pi * self.kappa**2)
-        anchor_coordinates = np.repeat(anchor_coordinates, num_references, axis=0)
-        offsets = self.sample_offsets(
-            radius=self.kappa,
-            num_samples=len(anchor_coordinates),
-        )
-        reference_coordinates = anchor_coordinates + offsets
-        anchor_coordinates = anchor_coordinates[np.newaxis, ...]
-        reference_coordinates = reference_coordinates[np.newaxis, ...]
-        anchor_coordinates = torch.from_numpy(np.repeat(anchor_coordinates, b, 0)).to(
-            self.device
-        )
-        reference_coordinates = torch.from_numpy(
-            np.repeat(reference_coordinates, b, 0)
-        ).to(self.device)
-        anchor_embeddings = self.get_embeddings(
-            prediction,
-            anchor_coordinates,
-        )  # B x N x 2/3
-        reference_embeddings = self.get_embeddings(
-            prediction,
-            reference_coordinates,
-        )  # B x N x 2/3
+    def forward(self, anchor_embedding, reference_embedding):
         distance = self.distance_function(
-            anchor_embeddings, reference_embeddings.detach()
+            anchor_embedding, reference_embedding.detach()
         )
-        oce_loss = self.nonlinearity(distance)
-        regularization_loss = self.regularization_weight * anchor_embeddings.norm(
-            2, dim=-1
+        non_linear_distance = self.non_linearity(distance)
+        oce_loss = non_linear_distance.sum()
+        regularization_loss = (
+            self.regularization_weight * anchor_embedding.norm(2, dim=-1).sum()
         )
-
         loss = oce_loss + regularization_loss
-        if self.reduce_mean:
-            return loss.mean(), oce_loss.mean(), regularization_loss.mean()
-        else:
-            return loss.sum(), oce_loss.sum(), regularization_loss.sum()
-
-    def sample_offsets(self, radius, num_samples):
-        if self.num_spatial_dims == 2:
-            offset_x = np.random.randint(-radius, radius + 1, size=2 * num_samples)
-            offset_y = np.random.randint(-radius, radius + 1, size=2 * num_samples)
-
-            offset_coordinates = np.stack((offset_x, offset_y), axis=1)
-        elif self.num_spatial_dims == 3:
-            offset_x = np.random.randint(-radius, radius + 1, size=3 * num_samples)
-            offset_y = np.random.randint(-radius, radius + 1, size=3 * num_samples)
-            offset_z = np.random.randint(-radius, radius + 1, size=3 * num_samples)
-
-            offset_coordinates = np.stack((offset_x, offset_y, offset_z), axis=1)
-        in_circle = (offset_coordinates**2).sum(axis=1) < radius**2
-        offset_coordinates = offset_coordinates[in_circle]
-        not_zero = np.absolute(offset_coordinates).sum(axis=1) > 0
-        offset_coordinates = offset_coordinates[not_zero]
-        if len(offset_coordinates) < num_samples:
-            return self.sample_offsets(radius, num_samples)
-
-        return offset_coordinates[:num_samples]
-
-    def get_embeddings(self, predictions, coordinates):
-        selection = []
-        for prediction, coordinate in zip(predictions, coordinates):
-            if self.num_spatial_dims == 2:
-                embedding = prediction[
-                    :, coordinate[:, 1].long(), coordinate[:, 0].long()
-                ]
-            elif self.num_spatial_dims == 3:
-                embedding = prediction[
-                    :,
-                    coordinate[:, 2].long(),
-                    coordinate[:, 1].long(),
-                    coordinate[:, 0].long(),
-                ]
-            embedding = embedding.transpose(1, 0)
-            embedding += coordinate
-            selection.append(embedding)
-
-        # selection.shape = (b, c, p) where p is the number of selected positions
-        return torch.stack(selection, dim=0)
+        return loss, oce_loss, regularization_loss

--- a/cellulus/datasets/__init__.py
+++ b/cellulus/datasets/__init__.py
@@ -11,6 +11,9 @@ def get_dataset(
     elastic_deform: bool,
     control_point_spacing: int,
     control_point_jitter: float,
+    density: float,
+    kappa: int,
+    normalization_factor: float,
 ) -> ZarrDataset:
     return ZarrDataset(
         dataset_config=dataset_config,
@@ -18,4 +21,7 @@ def get_dataset(
         elastic_deform=elastic_deform,
         control_point_spacing=control_point_spacing,
         control_point_jitter=control_point_jitter,
+        density=density,
+        kappa=kappa,
+        normalization_factor=normalization_factor,
     )

--- a/cellulus/datasets/__init__.py
+++ b/cellulus/datasets/__init__.py
@@ -8,12 +8,14 @@ from cellulus.datasets.zarr_dataset import ZarrDataset
 def get_dataset(
     dataset_config: DatasetConfig,
     crop_size: Tuple[int, ...],
+    elastic_deform: bool,
     control_point_spacing: int,
     control_point_jitter: float,
 ) -> ZarrDataset:
     return ZarrDataset(
         dataset_config=dataset_config,
         crop_size=crop_size,
+        elastic_deform=elastic_deform,
         control_point_spacing=control_point_spacing,
         control_point_jitter=control_point_jitter,
     )

--- a/cellulus/datasets/zarr_dataset.py
+++ b/cellulus/datasets/zarr_dataset.py
@@ -2,6 +2,7 @@ import math
 from typing import Tuple
 
 import gunpowder as gp
+import numpy as np
 from torch.utils.data import IterableDataset
 
 from cellulus.configs import DatasetConfig
@@ -17,6 +18,9 @@ class ZarrDataset(IterableDataset):  # type: ignore
         elastic_deform: bool,
         control_point_spacing: int,
         control_point_jitter: float,
+        density: float,
+        kappa: float,
+        normalization_factor: float,
     ):
         """A dataset that serves random samples from a zarr container.
 
@@ -56,6 +60,20 @@ class ZarrDataset(IterableDataset):  # type: ignore
                 of the raw data, given as the standard deviation of a normal
                 distribution with zero mean.
                 Only used if `elastic_deform` is set to True.
+
+            density:
+
+                Determines the fraction of patches to sample per crop, during training.
+
+            kappa:
+
+                Neighborhood radius to extract patches from.
+
+            normalization_factor:
+
+                The factor to use, for dividing the raw image pixel intensities.
+                If 'None', a factor is chosen based on the dtype of the array .
+                (e.g., np.uint8 would result in a factor of 1.0/255).
         """
 
         self.dataset_config = dataset_config
@@ -63,12 +81,20 @@ class ZarrDataset(IterableDataset):  # type: ignore
         self.elastic_deform = elastic_deform
         self.control_point_spacing = control_point_spacing
         self.control_point_jitter = control_point_jitter
+        self.normalization_factor = normalization_factor
         self.__read_meta_data()
 
         assert len(crop_size) == self.num_spatial_dims, (
             f'"crop_size" must have the same dimension as the '
             f'spatial(temporal) dimensions of the "{self.dataset_config.dataset_name}" '
             f"dataset which is {self.num_spatial_dims}, but it is {crop_size}"
+        )
+        self.density = density
+        self.kappa = kappa
+        self.output_shape = tuple(int(_ - 16) for _ in self.crop_size)
+        self.normalization_factor = normalization_factor
+        self.unbiased_shape = tuple(
+            int(_ - (2 * self.kappa)) for _ in self.output_shape
         )
         self.__setup_pipeline()
 
@@ -91,7 +117,9 @@ class ZarrDataset(IterableDataset):  # type: ignore
                 array_specs={self.raw: raw_spec},
             )
             + gp.RandomLocation()
+            + gp.Normalize(self.raw, factor=self.normalization_factor)
         )
+
         if self.elastic_deform:
             self.pipeline += gp.ElasticAugment(
                 control_point_spacing=(self.control_point_spacing,)
@@ -118,8 +146,9 @@ class ZarrDataset(IterableDataset):  # type: ignore
                 )
 
                 sample = self.pipeline.request_batch(request)
-
-                yield sample[self.raw].data[0]
+                sample_data = sample[self.raw].data[0]
+                anchor_samples, reference_samples = self.sample_coordinates()
+                yield sample_data, anchor_samples, reference_samples
 
     def __read_meta_data(self):
         meta_data = DatasetMetaData.from_dataset_config(self.dataset_config)
@@ -137,3 +166,79 @@ class ZarrDataset(IterableDataset):  # type: ignore
 
     def get_num_spatial_dims(self):
         return self.num_spatial_dims
+
+    def sample_offsets_within_radius(self, radius, number_offsets):
+        if self.num_spatial_dims == 2:
+            offsets_x = np.random.randint(-radius, radius + 1, size=2 * number_offsets)
+            offsets_y = np.random.randint(-radius, radius + 1, size=2 * number_offsets)
+            offsets_coordinates = np.stack((offsets_x, offsets_y), axis=1)
+        elif self.num_spatial_dims == 3:
+            offsets_x = np.random.randint(-radius, radius + 1, size=3 * number_offsets)
+            offsets_y = np.random.randint(-radius, radius + 1, size=3 * number_offsets)
+            offsets_z = np.random.randint(-radius, radius + 1, size=3 * number_offsets)
+            offsets_coordinates = np.stack((offsets_x, offsets_y, offsets_z), axis=1)
+
+        in_circle = (offsets_coordinates**2).sum(axis=1) < radius**2
+        offsets_coordinates = offsets_coordinates[in_circle]
+        not_zero = np.absolute(offsets_coordinates).sum(axis=1) > 0
+        offsets_coordinates = offsets_coordinates[not_zero]
+
+        if len(offsets_coordinates) < number_offsets:
+            return self.sample_offsets_within_radius(radius, number_offsets)
+
+        return offsets_coordinates[:number_offsets]
+
+    def sample_coordinates(self):
+        num_anchors = self.get_num_anchors()
+        num_references = self.get_num_references()
+
+        if self.num_spatial_dims == 2:
+            anchor_coordinates_x = np.random.randint(
+                self.kappa,
+                self.output_shape[0] - self.kappa + 1,
+                size=num_anchors,
+            )
+            anchor_coordinates_y = np.random.randint(
+                self.kappa,
+                self.output_shape[1] - self.kappa + 1,
+                size=num_anchors,
+            )
+            anchor_coordinates = np.stack(
+                (anchor_coordinates_x, anchor_coordinates_y), axis=1
+            )
+        elif self.num_spatial_dims == 3:
+            anchor_coordinates_x = np.random.randint(
+                self.kappa,
+                self.output_shape[0] - self.kappa + 1,
+                size=num_anchors,
+            )
+            anchor_coordinates_y = np.random.randint(
+                self.kappa,
+                self.output_shape[1] - self.kappa + 1,
+                size=num_anchors,
+            )
+            anchor_coordinates_z = np.random.randint(
+                self.kappa,
+                self.output_shape[2] - self.kappa + 1,
+                size=num_anchors,
+            )
+            anchor_coordinates = np.stack(
+                (anchor_coordinates_x, anchor_coordinates_y, anchor_coordinates_z),
+                axis=1,
+            )
+        anchor_samples = np.repeat(anchor_coordinates, num_references, axis=0)
+        offset_in_pos_radius = self.sample_offsets_within_radius(
+            self.kappa, len(anchor_samples)
+        )
+        reference_samples = anchor_samples + offset_in_pos_radius
+
+        return anchor_samples, reference_samples
+
+    def get_num_anchors(self):
+        return int(self.density * self.unbiased_shape[0] * self.unbiased_shape[1])
+
+    def get_num_references(self):
+        return int(self.density * self.kappa**2 * np.pi)
+
+    def get_num_samples(self):
+        return self.get_num_anchors() * self.get_num_references()

--- a/cellulus/datasets/zarr_dataset.py
+++ b/cellulus/datasets/zarr_dataset.py
@@ -47,13 +47,15 @@ class ZarrDataset(IterableDataset):  # type: ignore
             control_point_spacing:
 
                 The distance in pixels between control points used for elastic
-                deformation of the raw data. Only used, if `elastic_deform` is set to True.
+                deformation of the raw data.
+                Only used, if `elastic_deform` is set to True.
 
             control_point_jitter:
 
                 How much to jitter the control points for elastic deformation
                 of the raw data, given as the standard deviation of a normal
-                distribution with zero mean. Only used if `elastic_deform` is set to True.
+                distribution with zero mean.
+                Only used if `elastic_deform` is set to True.
         """
 
         self.dataset_config = dataset_config
@@ -68,7 +70,6 @@ class ZarrDataset(IterableDataset):  # type: ignore
             f'spatial(temporal) dimensions of the "{self.dataset_config.dataset_name}" '
             f"dataset which is {self.num_spatial_dims}, but it is {crop_size}"
         )
-
         self.__setup_pipeline()
 
     def __iter__(self):
@@ -117,6 +118,7 @@ class ZarrDataset(IterableDataset):  # type: ignore
                 )
 
                 sample = self.pipeline.request_batch(request)
+
                 yield sample[self.raw].data[0]
 
     def __read_meta_data(self):

--- a/cellulus/evaluate.py
+++ b/cellulus/evaluate.py
@@ -18,23 +18,33 @@ def evaluate(inference_config: InferenceConfig) -> None:
     ds_groundtruth = f[inference_config.evaluation_dataset_config.dataset_name]
 
     for bandwidth in range(inference_config.num_bandwidths):
-        F1_list, SEG_list, TP_list, FP_list, FN_list = [], [], [], [], []
+        sample_list, F1_list, SEG_list, TP_list, FP_list, FN_list = (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
         SEG_dataset, n_ids_dataset = 0, 0
         for sample in tqdm(range(dataset_meta_data.num_samples)):
             groundtruth = ds_groundtruth[sample, 0].astype(np.uint16)
             prediction = ds_segmentation[sample, bandwidth].astype(np.uint16)
-            IoU, SEG_image, n_GTids_image = compute_pairwise_IoU(
-                prediction, groundtruth
-            )
-            F1_image, TP_image, FP_image, FN_image = compute_F1(IoU)
-            F1_list.append(F1_image)
-            SEG_list.append(SEG_image / n_GTids_image)
-            SEG_dataset += SEG_image
-            n_ids_dataset += n_GTids_image
-            TP_list.append(TP_image)
-            FP_list.append(FP_image)
-            FN_list.append(FN_image)
-            print(f"{sample}:, F1={F1_image:.3f}, SEG={SEG_image/n_GTids_image:.3f}")
+            returned_values = compute_pairwise_IoU(prediction, groundtruth)
+            if returned_values is not None:
+                IoU, SEG_image, n_GTids_image = returned_values
+                F1_image, TP_image, FP_image, FN_image = compute_F1(IoU)
+                F1_list.append(F1_image)
+                SEG_list.append(SEG_image / n_GTids_image)
+                SEG_dataset += SEG_image
+                n_ids_dataset += n_GTids_image
+                TP_list.append(TP_image)
+                FP_list.append(FP_image)
+                FN_list.append(FN_image)
+                sample_list.append(sample)
+                print(
+                    f"{sample}:, F1={F1_image:.3f}, SEG={SEG_image/n_GTids_image:.3f}"
+                )
 
         F1_dataset = 2 * sum(TP_list) / (2 * sum(TP_list) + sum(FP_list) + sum(FN_list))
 
@@ -45,9 +55,9 @@ def evaluate(inference_config: InferenceConfig) -> None:
         with open(txt_file, "w") as f:
             f.writelines("file index, F1, SEG, TP, FP, FN \n")
             f.writelines("+++++++++++++++++++++++++++++++++\n")
-            for sample in range(dataset_meta_data.num_samples):
+            for sample in range(len(sample_list)):
                 f.writelines(
-                    f"{sample},"
+                    f"{sample_list[sample]},"
                     + f" {F1_list[sample]:.05f},"
                     + f" {SEG_list[sample]:.05f},"
                     + f" {TP_list[sample]},"
@@ -67,23 +77,26 @@ def compute_pairwise_IoU(prediction, groundtruth):
     groundtruth_ids = np.unique(groundtruth)
     groundtruth_ids = groundtruth_ids[groundtruth_ids != 0]  # ignore background
 
-    IoU_table = np.zeros((len(prediction_ids), len(groundtruth_ids)), dtype=float)
-    IoG_table = np.zeros((len(prediction_ids), len(groundtruth_ids)), dtype=float)
-    for j in range(len(prediction_ids)):
-        for k in range(len(groundtruth_ids)):
-            intersection = (prediction == prediction_ids[j]) & (
-                groundtruth == groundtruth_ids[k]
-            )
-            union = (prediction == prediction_ids[j]) | (
-                groundtruth == groundtruth_ids[k]
-            )
-            IoU_table[j, k] = np.sum(intersection) / np.sum(union)
-            IoG_table[j, k] = np.sum(intersection) / np.sum(
-                groundtruth == groundtruth_ids[k]
-            )
-    # Note for SEG, we consider it a match if it is strictly
-    # greater than `0.5` IoU
-    return IoU_table, np.sum(IoU_table[IoG_table > 0.5]), len(groundtruth_ids)
+    if len(groundtruth_ids) == 0:
+        return None
+    else:
+        IoU_table = np.zeros((len(prediction_ids), len(groundtruth_ids)), dtype=float)
+        IoG_table = np.zeros((len(prediction_ids), len(groundtruth_ids)), dtype=float)
+        for j in range(len(prediction_ids)):
+            for k in range(len(groundtruth_ids)):
+                intersection = (prediction == prediction_ids[j]) & (
+                    groundtruth == groundtruth_ids[k]
+                )
+                union = (prediction == prediction_ids[j]) | (
+                    groundtruth == groundtruth_ids[k]
+                )
+                IoU_table[j, k] = np.sum(intersection) / np.sum(union)
+                IoG_table[j, k] = np.sum(intersection) / np.sum(
+                    groundtruth == groundtruth_ids[k]
+                )
+        # Note for SEG, we consider it a match if it is strictly
+        # greater than `0.5` IoU
+        return IoU_table, np.sum(IoU_table[IoG_table > 0.5]), len(groundtruth_ids)
 
 
 def compute_F1(IoU_table, threshold=0.5):

--- a/cellulus/evaluate.py
+++ b/cellulus/evaluate.py
@@ -42,9 +42,7 @@ def evaluate(inference_config: InferenceConfig) -> None:
                 FP_list.append(FP_image)
                 FN_list.append(FN_image)
                 sample_list.append(sample)
-                print(
-                    f"{sample}:, F1={F1_image:.3f}, SEG={SEG_image/n_GTids_image:.3f}"
-                )
+                print(f"{sample}: F1={F1_image:.3f}, SEG={SEG_image/n_GTids_image:.3f}")
 
         F1_dataset = 2 * sum(TP_list) / (2 * sum(TP_list) + sum(FP_list) + sum(FN_list))
 

--- a/cellulus/infer.py
+++ b/cellulus/infer.py
@@ -17,6 +17,7 @@ def infer(experiment_config):
     print(experiment_config)
 
     inference_config = experiment_config.inference_config
+    normalization_factor = experiment_config.normalization_factor
 
     model_config = experiment_config.model_config
 
@@ -25,7 +26,7 @@ def infer(experiment_config):
     )
 
     if inference_config.bandwidth is None:
-        inference_config.bandwidth = int(0.5 * experiment_config.object_size)
+        inference_config.bandwidth = int(0.25 * experiment_config.object_size)
 
     if inference_config.min_size is None:
         if dataset_meta_data.num_spatial_dims == 2:
@@ -67,13 +68,13 @@ def infer(experiment_config):
 
     # get predicted embeddings...
     if inference_config.prediction_dataset_config is not None:
-        predict(model, inference_config)
+        predict(model, inference_config, normalization_factor)
     # ...turn them into a segmentation...
     if inference_config.segmentation_dataset_config is not None:
         segment(inference_config)
     # ...and post-process the segmentation
     if inference_config.post_processed_dataset_config is not None:
         post_process(inference_config)
-    # ...and evaluate if groundtruth exists
+    # ...and evaluate if ground-truth exists
     if inference_config.evaluation_dataset_config is not None:
         evaluate(inference_config)

--- a/cellulus/infer.py
+++ b/cellulus/infer.py
@@ -26,7 +26,7 @@ def infer(experiment_config):
     )
 
     if inference_config.bandwidth is None:
-        inference_config.bandwidth = int(0.25 * experiment_config.object_size)
+        inference_config.bandwidth = 0.5 * experiment_config.object_size
 
     if inference_config.min_size is None:
         if dataset_meta_data.num_spatial_dims == 2:

--- a/cellulus/post_process.py
+++ b/cellulus/post_process.py
@@ -1,6 +1,8 @@
 import numpy as np
 import zarr
+from scipy.ndimage import binary_fill_holes, label
 from scipy.ndimage import distance_transform_edt as dtedt
+from skimage.filters import threshold_otsu
 from tqdm import tqdm
 
 from cellulus.configs.inference_config import InferenceConfig
@@ -38,16 +40,60 @@ def post_process(inference_config: InferenceConfig) -> None:
     ds_postprocessed.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims
 
     # remove halo
-    for sample in tqdm(range(dataset_meta_data.num_samples)):
-        # first instance label masks are expanded by `grow_distance`
-        # next, expanded  instance label masks are shrunk by `shrink_distance`
-        for bandwidth_factor in range(inference_config.num_bandwidths):
-            segmentation = ds[sample, bandwidth_factor]
-            distance_foreground = dtedt(segmentation == 0)
-            expanded_mask = distance_foreground < inference_config.grow_distance
-            distance_background = dtedt(expanded_mask)
-            segmentation[distance_background < inference_config.shrink_distance] = 0
-            ds_postprocessed[sample, bandwidth_factor, ...] = segmentation
+    if inference_config.post_processing == "morphological":
+        for sample in tqdm(range(dataset_meta_data.num_samples)):
+            # first instance label masks are expanded by `grow_distance`
+            # next, expanded  instance label masks are shrunk by `shrink_distance`
+            for bandwidth_factor in range(inference_config.num_bandwidths):
+                segmentation = ds[sample, bandwidth_factor]
+                distance_foreground = dtedt(segmentation == 0)
+                expanded_mask = distance_foreground < inference_config.grow_distance
+                distance_background = dtedt(expanded_mask)
+                segmentation[distance_background < inference_config.shrink_distance] = 0
+                ds_postprocessed[sample, bandwidth_factor, ...] = segmentation
+    elif inference_config.post_processing == "intensity":
+        ds_raw = f[inference_config.dataset_config.dataset_name]
+        for sample in tqdm(range(dataset_meta_data.num_samples)):
+            for bandwidth_factor in range(inference_config.num_bandwidths):
+                segmentation = ds[sample, bandwidth_factor]
+                raw_image = ds_raw[sample, 0]
+                ids = np.unique(segmentation)
+                ids = ids[ids != 0]
+                for id_ in ids:
+                    raw_image_masked = raw_image[segmentation == id_]
+                    threshold = threshold_otsu(raw_image_masked)
+                    mask = (segmentation == id_) & (raw_image > threshold)
+                    mask = binary_fill_holes(mask)
+                    if dataset_meta_data.num_spatial_dims == 2:
+                        y, x = np.where(mask)
+                        ds_postprocessed[sample, bandwidth_factor, y, x] = id_
+                    elif dataset_meta_data.num_spatial_dims == 3:
+                        z, y, x = np.where(mask)
+                        ds_postprocessed[sample, bandwidth_factor, z, y, x] = id_
+
+            # remove non-connected components
+            for bandwidth_factor in range(inference_config.num_bandwidths):
+                ids = np.unique(ds_postprocessed[sample, bandwidth_factor])
+                ids = ids[ids != 0]
+                counter = np.max(ids) + 1
+                for id_ in ids:
+                    ma_id = ds_postprocessed[sample, bandwidth_factor] == id_
+                    array, num_features = label(ma_id)
+                    if num_features > 1:
+                        ids_array = np.unique(array)
+                        ids_array = ids_array[ids_array != 0]
+                        for id_array in ids_array:
+                            if dataset_meta_data.num_spatial_dims == 2:
+                                y, x = np.where(array == id_array)
+                                ds_postprocessed[
+                                    sample, bandwidth_factor, y, x
+                                ] = counter
+                            elif dataset_meta_data.num_spatial_dims == 3:
+                                z, y, x = np.where(array == id_array)
+                                ds_postprocessed[
+                                    sample, bandwidth_factor, z, y, x
+                                ] = counter
+                            counter += 1
 
     # size filter - remove small objects
     for sample in tqdm(range(dataset_meta_data.num_samples)):

--- a/cellulus/post_process.py
+++ b/cellulus/post_process.py
@@ -40,7 +40,7 @@ def post_process(inference_config: InferenceConfig) -> None:
     ds_postprocessed.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims
 
     # remove halo
-    if inference_config.post_processing == "morphological":
+    if inference_config.post_processing == "cell":
         for sample in tqdm(range(dataset_meta_data.num_samples)):
             # first instance label masks are expanded by `grow_distance`
             # next, expanded  instance label masks are shrunk by `shrink_distance`
@@ -51,7 +51,7 @@ def post_process(inference_config: InferenceConfig) -> None:
                 distance_background = dtedt(expanded_mask)
                 segmentation[distance_background < inference_config.shrink_distance] = 0
                 ds_postprocessed[sample, bandwidth_factor, ...] = segmentation
-    elif inference_config.post_processing == "intensity":
+    elif inference_config.post_processing == "nucleus":
         ds_raw = f[inference_config.dataset_config.dataset_name]
         for sample in tqdm(range(dataset_meta_data.num_samples)):
             for bandwidth_factor in range(inference_config.num_bandwidths):

--- a/cellulus/predict.py
+++ b/cellulus/predict.py
@@ -107,13 +107,6 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
         dtype=float,
     )
 
-    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
-        -dataset_meta_data.num_spatial_dims :
-    ]
-
-    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
-    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims
-
     pipeline = (
         gp.ZarrSource(
             dataset_config.container_path,
@@ -135,3 +128,10 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
     # request to pipeline for ROI of whole image/volume
     with gp.build(pipeline):
         pipeline.request_batch(request)
+
+    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
+        -dataset_meta_data.num_spatial_dims :
+    ]
+
+    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
+    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims

--- a/cellulus/predict.py
+++ b/cellulus/predict.py
@@ -6,7 +6,11 @@ from cellulus.configs.inference_config import InferenceConfig
 from cellulus.datasets.meta_data import DatasetMetaData
 
 
-def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
+def predict(
+    model: torch.nn.Module,
+    inference_config: InferenceConfig,
+    normalization_factor: float,
+) -> None:
     # get the dataset_config data out of inference_config
     dataset_config = inference_config.dataset_config
     dataset_meta_data = DatasetMetaData.from_dataset_config(dataset_config)
@@ -113,6 +117,7 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
             {raw: dataset_config.dataset_name},
             {raw: gp.ArraySpec(voxel_size=voxel_size, interpolatable=True)},
         )
+        + gp.Normalize(raw, factor=normalization_factor)
         + gp.Pad(raw, context, mode="reflect")
         + predict
         + gp.ZarrWrite(

--- a/cellulus/predict.py
+++ b/cellulus/predict.py
@@ -107,6 +107,13 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
         dtype=float,
     )
 
+    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
+        -dataset_meta_data.num_spatial_dims :
+    ]
+
+    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
+    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims
+
     pipeline = (
         gp.ZarrSource(
             dataset_config.container_path,
@@ -128,10 +135,3 @@ def predict(model: torch.nn.Module, inference_config: InferenceConfig) -> None:
     # request to pipeline for ROI of whole image/volume
     with gp.build(pipeline):
         pipeline.request_batch(request)
-
-    ds.attrs["axis_names"] = ["s", "c"] + ["t", "z", "y", "x"][
-        -dataset_meta_data.num_spatial_dims :
-    ]
-
-    ds.attrs["resolution"] = (1,) * dataset_meta_data.num_spatial_dims
-    ds.attrs["offset"] = (0,) * dataset_meta_data.num_spatial_dims

--- a/cellulus/train.py
+++ b/cellulus/train.py
@@ -27,6 +27,7 @@ def train(experiment_config):
     train_dataset = get_dataset(
         dataset_config=train_config.train_data_config,
         crop_size=tuple(train_config.crop_size),
+        elastic_deform=train_config.elastic_deform,
         control_point_spacing=train_config.control_point_spacing,
         control_point_jitter=train_config.control_point_jitter,
     )

--- a/cellulus/train.py
+++ b/cellulus/train.py
@@ -127,8 +127,8 @@ def train(experiment_config):
         logger.plot()
 
         if iteration % train_config.save_model_every == 0:
-            is_lowest = oce_loss < lowest_loss
-            lowest_loss = min(oce_loss, lowest_loss)
+            is_lowest = loss < lowest_loss
+            lowest_loss = min(loss, lowest_loss)
             state = {
                 "iteration": iteration,
                 "lowest_loss": lowest_loss,
@@ -150,11 +150,6 @@ def train_iteration(batch, model, criterion, optimizer, device):
     model.train()
     prediction = model(batch.to(device))
     loss, oce_loss, regularization_loss = criterion(prediction)
-    loss, oce_loss, regularization_loss = (
-        loss.mean(),
-        oce_loss.mean(),
-        regularization_loss.mean(),
-    )
     optimizer.zero_grad()
     loss.backward()
     optimizer.step()

--- a/cellulus/train.py
+++ b/cellulus/train.py
@@ -127,7 +127,10 @@ def train(experiment_config):
         logger.write()
         logger.plot()
 
-        if iteration % train_config.save_model_every == 0:
+        if (
+            iteration % train_config.save_model_every == 0
+            or iteration == train_config.max_iterations - 1
+        ):
             is_lowest = loss < lowest_loss
             lowest_loss = min(loss, lowest_loss)
             state = {

--- a/cellulus/utils/greedy_cluster.py
+++ b/cellulus/utils/greedy_cluster.py
@@ -80,7 +80,7 @@ class Cluster2d:
 
 
         """
-        prediction = torch.from_numpy(prediction).to(self.device)
+        prediction = torch.from_numpy(prediction).float().to(self.device)
         height, width = prediction.size(1), prediction.size(2)
         xym_s = self.xym[:, 0:height, 0:width]
         embeddings = prediction[0:2] + xym_s  # 2 x h x w

--- a/cellulus/utils/greedy_cluster.py
+++ b/cellulus/utils/greedy_cluster.py
@@ -1,0 +1,252 @@
+import numpy as np
+import torch
+
+
+class Cluster2d:
+    """
+    Class for Greedy Clustering of Embeddings on 2D samples.
+    """
+    def __init__(self, width, height, fg_mask, device):
+        """Initializes objects of class `Cluster2d`.
+
+        Parameters
+        ----------
+            
+            width: 
+            
+                Width (`W`) of the Raw Image, in number of pixels.
+
+            height:
+
+                Height (`H`) of the Raw Image, in number of pixels.
+
+            fg_mask: (shape is `H` x `W`)
+
+                Foreground Mask corresponding to the region which should be
+                partitioned into individual objects.
+
+            device: 
+
+                Device on which inference is being run.
+
+        """
+        
+        xm = torch.linspace(0, width - 1, width).view(1, 1, -1).expand(1, height, width)
+        ym = (
+            torch.linspace(0, height - 1, height)
+            .view(1, -1, 1)
+            .expand(1, height, width)
+        )
+        xym = torch.cat((xm, ym), 0)
+        self.device = device
+        self.fg_mask = torch.from_numpy(fg_mask[np.newaxis]).to(self.device)
+        self.xym = xym.to(self.device)
+
+    def cluster(
+        self,
+        prediction,
+        bandwidth,
+        min_object_size,
+        seed_thresh=0.9,
+        min_unclustered_sum=0,
+    ):
+        """Cluster Function.
+
+        Parameters
+        ----------
+
+            prediction: (shape is 3 x `H` x `W`)
+
+                Embeddings predicted for the whole raw imnage sample.
+
+            bandwidth: 
+
+                Clustering bandwidth or sigma.
+
+            min_object_size:
+
+                Clusters below the `min_object_size` are ignored.
+
+            seed_thresh (default = 0.9): 
+
+                Pixels with certainty below 0.9 are ignored to be object
+                centers.
+
+            min_unclustered_sum (default = 0):
+
+                If number of pixels which have not been clustered yet falls
+                below min_unclustered_sum, the clustering proces stops.
+
+                
+        """
+        prediction = torch.from_numpy(prediction).to(self.device)
+        height, width = prediction.size(1), prediction.size(2)
+        xym_s = self.xym[:, 0:height, 0:width]
+        embeddings = prediction[0:2] + xym_s  # 2 x h x w
+        seed_map = prediction[2:3]  # 1 x h x w
+        seed_map_min = seed_map.min()
+        seed_map_max = seed_map.max()
+        seed_map = (seed_map - seed_map_max) / (seed_map_min - seed_map_max)
+        instance_map = torch.zeros(height, width).short()
+        count = 1
+
+        embeddings_masked = embeddings[self.fg_mask.expand_as(embeddings)].view(2, -1)
+        seed_map_masked = seed_map[self.fg_mask].view(1, -1)
+        unclustered = torch.ones(self.fg_mask.sum()).short().to(self.device)
+        instance_map_masked = torch.zeros(self.fg_mask.sum()).short().to(self.device)
+        while unclustered.sum() > min_unclustered_sum:
+            seed = (seed_map_masked * unclustered.float()).argmax().item()
+            seed_score = (seed_map_masked * unclustered.float()).max().item()
+            if seed_score < seed_thresh:
+                break
+            center = embeddings_masked[:, seed : seed + 1]
+            unclustered[seed] = 0
+            dist = torch.exp(
+                -1
+                * torch.sum(
+                    torch.pow(embeddings_masked - center, 2) / (2 * (bandwidth**2)), 0
+                )
+            )
+            proposal = (dist > 0.5).squeeze()
+            if proposal.sum() > min_object_size:
+                if unclustered[proposal].sum().float() / proposal.sum().float() > 0.5:
+                    instance_map_masked[proposal.squeeze()] = count
+                    instance_mask = torch.zeros(height, width).short()
+                    instance_mask[self.fg_mask.squeeze().cpu()] = proposal.short().cpu()
+                    count += 1
+            unclustered[proposal] = 0
+        instance_map[self.fg_mask.squeeze().cpu()] = instance_map_masked.cpu()
+        return instance_map
+
+
+class Cluster3d:
+    """
+    Class for Greedy Clustering of Embeddings for 3D samples.
+    """
+    def __init__(self, width, height, depth, fg_mask, device):
+        
+        """Initializes objects of class `Cluster3d`.
+
+        Parameters
+        ----------
+            
+            width: 
+            
+                Width (`W`) of the Raw Image, in number of pixels.
+
+            height:
+
+                Height (`H`) of the Raw Image, in number of pixels.
+
+            depth:
+
+                Depth (`D`) of the Raw Image, in number of pixels. 
+
+            fg_mask: (shape is `D` x `H` x `W`)
+
+                Foreground Mask corresponding to the region which should be
+                partitioned into individual objects.
+
+            device: 
+
+                Device on which inference is being run.
+
+        """
+        xm = (
+            torch.linspace(0, width - 1, width)
+            .view(1, 1, 1, -1)
+            .expand(1, depth, height, width)
+        )
+        ym = (
+            torch.linspace(0, height - 1, height)
+            .view(1, 1, -1, 1)
+            .expand(1, depth, height, width)
+        )
+        zm = (
+            torch.linspace(0, depth - 1, depth)
+            .view(1, -1, 1, 1)
+            .expand(1, depth, height, width)
+        )
+        xyzm = torch.cat((xm, ym, zm), 0)
+        self.device = device
+        self.fg_mask = torch.from_numpy(fg_mask[np.newaxis]).to(self.device)
+        self.xyzm = xyzm.to(self.device)
+
+    def cluster(
+        self,
+        prediction,
+        bandwidth,
+        min_object_size,
+        seed_thresh=0.9,
+        min_unclustered_sum=0,
+    ):
+        
+        """Cluster Function..
+
+        Parameters
+        ----------
+
+            prediction: (shape is 3 x `D` x `H` x `W`)
+
+                Embeddings predicted for the whole raw imnage sample.
+
+            bandwidth: 
+
+                Clustering bandwidth or sigma.
+
+            min_object_size:
+
+                Clusters below the `min_object_size` are ignored.
+
+            seed_thresh (default = 0.9): 
+
+                Pixels with certainty below 0.9 are ignored to be object
+                centers.
+
+            min_unclustered_sum (default = 0):
+
+                If number of pixels which have not been clustered yet falls
+                below min_unclustered_sum, the clustering proces stops.
+
+        """        
+        prediction = torch.from_numpy(prediction).to(self.device)
+        depth, height, width = (
+            prediction.size(1),
+            prediction.size(2),
+            prediction.size(3))
+        xyzm_s = self.xyzm[:, 0:depth, 0:height, 0:width]
+        embeddings = prediction[0:3] + xyzm_s  # 3 x d x h x w
+        seed_map = prediction[3:4]  # 1 x d x h x w
+        seed_map_min = seed_map.min()
+        seed_map_max = seed_map.max()
+        seed_map = (seed_map - seed_map_max) / (seed_map_min - seed_map_max)
+        instance_map = torch.zeros(depth, height, width).short()
+        count = 1
+
+        embeddings_masked = embeddings[self.fg_mask.expand_as(embeddings)].view(3, -1)
+        seed_map_masked = seed_map[self.fg_mask].view(1, -1)
+        unclustered = torch.ones(self.fg_mask.sum()).short().to(self.device)
+        instance_map_masked = torch.zeros(self.fg_mask.sum()).short().to(self.device)
+        while unclustered.sum() > min_unclustered_sum:
+            seed = (seed_map_masked * unclustered.float()).argmax().item()
+            seed_score = (seed_map_masked * unclustered.float()).max().item()
+            if seed_score < seed_thresh:
+                break
+            center = embeddings_masked[:, seed : seed + 1]
+            unclustered[seed] = 0
+            dist = torch.exp(
+                -1
+                * torch.sum(
+                    torch.pow(embeddings_masked - center, 2) / (2 * (bandwidth**2)), 0
+                )
+            )
+            proposal = (dist > 0.5).squeeze()
+            if proposal.sum() > min_object_size:
+                if unclustered[proposal].sum().float() / proposal.sum().float() > 0.5:
+                    instance_map_masked[proposal.squeeze()] = count
+                    instance_mask = torch.zeros(depth, height, width).short()
+                    instance_mask[self.fg_mask.squeeze().cpu()] = proposal.short().cpu()
+                    count += 1
+            unclustered[proposal] = 0
+        instance_map[self.fg_mask.squeeze().cpu()] = instance_map_masked.cpu()
+        return instance_map

--- a/cellulus/utils/greedy_cluster.py
+++ b/cellulus/utils/greedy_cluster.py
@@ -6,14 +6,15 @@ class Cluster2d:
     """
     Class for Greedy Clustering of Embeddings on 2D samples.
     """
+
     def __init__(self, width, height, fg_mask, device):
         """Initializes objects of class `Cluster2d`.
 
         Parameters
         ----------
-            
-            width: 
-            
+
+            width:
+
                 Width (`W`) of the Raw Image, in number of pixels.
 
             height:
@@ -25,12 +26,12 @@ class Cluster2d:
                 Foreground Mask corresponding to the region which should be
                 partitioned into individual objects.
 
-            device: 
+            device:
 
                 Device on which inference is being run.
 
         """
-        
+
         xm = torch.linspace(0, width - 1, width).view(1, 1, -1).expand(1, height, width)
         ym = (
             torch.linspace(0, height - 1, height)
@@ -59,7 +60,7 @@ class Cluster2d:
 
                 Embeddings predicted for the whole raw imnage sample.
 
-            bandwidth: 
+            bandwidth:
 
                 Clustering bandwidth or sigma.
 
@@ -67,7 +68,7 @@ class Cluster2d:
 
                 Clusters below the `min_object_size` are ignored.
 
-            seed_thresh (default = 0.9): 
+            seed_thresh (default = 0.9):
 
                 Pixels with certainty below 0.9 are ignored to be object
                 centers.
@@ -77,7 +78,7 @@ class Cluster2d:
                 If number of pixels which have not been clustered yet falls
                 below min_unclustered_sum, the clustering proces stops.
 
-                
+
         """
         prediction = torch.from_numpy(prediction).to(self.device)
         height, width = prediction.size(1), prediction.size(2)
@@ -123,15 +124,15 @@ class Cluster3d:
     """
     Class for Greedy Clustering of Embeddings for 3D samples.
     """
+
     def __init__(self, width, height, depth, fg_mask, device):
-        
         """Initializes objects of class `Cluster3d`.
 
         Parameters
         ----------
-            
-            width: 
-            
+
+            width:
+
                 Width (`W`) of the Raw Image, in number of pixels.
 
             height:
@@ -140,14 +141,14 @@ class Cluster3d:
 
             depth:
 
-                Depth (`D`) of the Raw Image, in number of pixels. 
+                Depth (`D`) of the Raw Image, in number of pixels.
 
             fg_mask: (shape is `D` x `H` x `W`)
 
                 Foreground Mask corresponding to the region which should be
                 partitioned into individual objects.
 
-            device: 
+            device:
 
                 Device on which inference is being run.
 
@@ -180,7 +181,6 @@ class Cluster3d:
         seed_thresh=0.9,
         min_unclustered_sum=0,
     ):
-        
         """Cluster Function..
 
         Parameters
@@ -190,7 +190,7 @@ class Cluster3d:
 
                 Embeddings predicted for the whole raw imnage sample.
 
-            bandwidth: 
+            bandwidth:
 
                 Clustering bandwidth or sigma.
 
@@ -198,7 +198,7 @@ class Cluster3d:
 
                 Clusters below the `min_object_size` are ignored.
 
-            seed_thresh (default = 0.9): 
+            seed_thresh (default = 0.9):
 
                 Pixels with certainty below 0.9 are ignored to be object
                 centers.
@@ -208,12 +208,13 @@ class Cluster3d:
                 If number of pixels which have not been clustered yet falls
                 below min_unclustered_sum, the clustering proces stops.
 
-        """        
+        """
         prediction = torch.from_numpy(prediction).to(self.device)
         depth, height, width = (
             prediction.size(1),
             prediction.size(2),
-            prediction.size(3))
+            prediction.size(3),
+        )
         xyzm_s = self.xyzm[:, 0:depth, 0:height, 0:width]
         embeddings = prediction[0:3] + xyzm_s  # 3 x d x h x w
         seed_map = prediction[3:4]  # 1 x d x h x w

--- a/cellulus/utils/mean_shift.py
+++ b/cellulus/utils/mean_shift.py
@@ -1,6 +1,5 @@
 import numpy as np
 import torch
-from skimage import measure
 from sklearn.cluster import MeanShift
 
 
@@ -36,7 +35,6 @@ def mean_shift_segmentation(
         reduction_probability=reduction_probability,
         cluster_all=False,
     )[0]
-    segmentation = sizefilter(segmentation, min_size)
     return segmentation
 
 
@@ -47,22 +45,6 @@ def segment_with_meanshift(
         bandwidth, reduction_probability=reduction_probability, cluster_all=cluster_all
     )
     return anchor_mean_shift(embedding, mask=mask) + 1
-
-
-def sizefilter(segmentation, min_size, filter_non_connected=True):
-    if min_size == 0:
-        return segmentation
-
-    if filter_non_connected:
-        filter_labels = measure.label(segmentation, background=0)
-    else:
-        filter_labels = segmentation
-    ids, sizes = np.unique(filter_labels, return_counts=True)
-    filter_ids = ids[sizes < min_size]
-    mask = np.in1d(filter_labels, filter_ids).reshape(filter_labels.shape)
-    segmentation[mask] = 0
-
-    return segmentation
 
 
 class AnchorMeanshift:

--- a/cellulus/utils/misc.py
+++ b/cellulus/utils/misc.py
@@ -4,6 +4,24 @@ from urllib.request import urlopen
 from zipfile import ZipFile
 
 import matplotlib.pyplot as plt
+import numpy as np
+from skimage import measure
+
+
+def size_filter(segmentation, min_size, filter_non_connected=True):
+    if min_size == 0:
+        return segmentation
+
+    if filter_non_connected:
+        filter_labels = measure.label(segmentation, background=0)
+    else:
+        filter_labels = segmentation
+    ids, sizes = np.unique(filter_labels, return_counts=True)
+    filter_ids = ids[sizes < min_size]
+    mask = np.in1d(filter_labels, filter_ids).reshape(filter_labels.shape)
+    segmentation[mask] = 0
+
+    return segmentation
 
 
 def extract_data(zip_url, data_dir, project_name):

--- a/docs/examples/2d/01-data.py
+++ b/docs/examples/2d/01-data.py
@@ -1,6 +1,7 @@
 # # Download Data
 
-# In this notebook, we will download data and convert it to a zarr dataset.
+# In this notebook, we will download data and convert it to a zarr dataset. <br>
+# This tutorial was written by <i>Henry Westmacott</i> and <i>Manan Lalit</i>.
 
 # For demonstration, we will use a subset of images of `Fluo-N2DL-HeLa` available on the [Cell Tracking Challenge](http://celltrackingchallenge.net/2d-datasets/) webpage.
 

--- a/docs/examples/2d/01-data.py
+++ b/docs/examples/2d/01-data.py
@@ -3,7 +3,9 @@
 # In this notebook, we will download data and convert it to a zarr dataset. <br>
 # This tutorial was written by <i>Henry Westmacott</i> and <i>Manan Lalit</i>.
 
-# For demonstration, we will use a subset of images of `Fluo-N2DL-HeLa` available on the [Cell Tracking Challenge](http://celltrackingchallenge.net/2d-datasets/) webpage.
+# For demonstration, we will use a subset of images of `Fluo-N2DL-HeLa` available
+# on the [Cell Tracking Challenge](http://celltrackingchallenge.net/2d-datasets/)
+# webpage.
 
 # Firstly, the `tif` raw images are downloaded to a directory indicated by `data_dir`.
 
@@ -27,7 +29,7 @@ extract_data(
 )
 # -
 
-# Next, these raw images are intensity-normalized and appended in a list. Here, we use the percentile normalization technique.
+# Next,  a channel dimension is added to these images and they are appended in a list.
 
 # +
 container_path = zarr.open(name + ".zarr")
@@ -38,10 +40,7 @@ image_list = []
 
 for i in tqdm(range(len(image_filenames))):
     im = normalize(
-        tifffile.imread(image_filenames[i]).astype(np.float32),
-        pmin=1,
-        pmax=99.8,
-        axis=(0, 1),
+        tifffile.imread(image_filenames[i]).astype(np.float32), 1, 99.8, axis=(0, 1)
     )
     image_list.append(im[np.newaxis, ...])
 

--- a/docs/examples/2d/02-train.py
+++ b/docs/examples/2d/02-train.py
@@ -33,9 +33,9 @@ model_config = ModelConfig(num_fmaps=num_fmaps, fmap_inc_factor=fmap_inc_factor)
 
 # Then, we specify training-specific parameters such as the `device`, which indicates the actual device to run the training on.
 # <br> The device could be set equal to `cuda:n` (where `n` is the index of the GPU, for e.g. `cuda:0`), `cpu` or `mps`. <br>
-# We set the `max_iterations` equal to `5e3` for demonstration purposes. <br>(This takes around 20 minutes on a Mac Book Pro with an Apple M2 Max chip).
+# We set the `max_iterations` equal to 5000 for demonstration purposes. <br>(This takes around 20 minutes on a Mac Book Pro with an Apple M2 Max chip).
 
-device = "mps"
+device = "cuda:0"
 max_iterations = 5000
 
 train_config = TrainConfig(

--- a/docs/examples/2d/02-train.py
+++ b/docs/examples/2d/02-train.py
@@ -41,7 +41,7 @@ model_config = ModelConfig(num_fmaps=num_fmaps, fmap_inc_factor=fmap_inc_factor)
 # We set the `max_iterations` equal to 5000 for demonstration purposes.
 # <br>(This takes around 20 minutes on a Mac Book Pro with an Apple M2 Max chip).
 
-device = "mps"  # 'mps', 'cpu', 'cuda:0'
+device = "cuda:0"  # 'mps', 'cpu', 'cuda:0'
 max_iterations = 5000
 
 train_config = TrainConfig(
@@ -62,5 +62,6 @@ experiment_config = ExperimentConfig(
 # Now we can begin the training! <br>
 # Uncomment the next two lines to train the model.
 
+# +
 # from cellulus.train import train
 # train(experiment_config)

--- a/docs/examples/2d/02-train.py
+++ b/docs/examples/2d/02-train.py
@@ -56,3 +56,4 @@ experiment_config = ExperimentConfig(
 # +
 # from cellulus.train import train
 # train(experiment_config)
+# -

--- a/docs/examples/2d/02-train.py
+++ b/docs/examples/2d/02-train.py
@@ -10,7 +10,8 @@ from cellulus.configs.train_config import TrainConfig
 
 # ## Specify config values for dataset
 
-# In the next cell, we specify the name of the zarr container and the dataset within it from which data would be read.
+# In the next cell, we specify the name of the zarr container and the dataset
+# within it from which data would be read.
 
 name = "2d-data-demo"
 dataset_name = "train/raw"
@@ -21,8 +22,10 @@ train_data_config = DatasetConfig(
 
 # ## Specify config values for model
 
-# In the next cell, we specify the number of feature maps (`num_fmaps`) in the first layer in our model. <br>
-# Additionally, we specify `fmap_inc_factor`, which indicates by how much the number of feature maps increase between adjacent layers.
+# In the next cell, we specify the number of feature maps (`num_fmaps`) in the
+# first layer in our model. <br>
+# Additionally, we specify `fmap_inc_factor`, which indicates by how much the
+# number of feature maps increase between adjacent layers.
 
 num_fmaps = 24
 fmap_inc_factor = 3
@@ -31,11 +34,14 @@ model_config = ModelConfig(num_fmaps=num_fmaps, fmap_inc_factor=fmap_inc_factor)
 
 # ## Specify config values for the training process
 
-# Then, we specify training-specific parameters such as the `device`, which indicates the actual device to run the training on.
-# <br> The device could be set equal to `cuda:n` (where `n` is the index of the GPU, for e.g. `cuda:0`), `cpu` or `mps`. <br>
-# We set the `max_iterations` equal to 5000 for demonstration purposes. <br>(This takes around 20 minutes on a Mac Book Pro with an Apple M2 Max chip).
+# Then, we specify training-specific parameters such as the `device`,
+# which indicates the actual device to run the training on.
+# <br> The device could be set equal to `cuda:n` (where `n` is the index of
+# the GPU, for e.g. `cuda:0`), `cpu` or `mps`. <br>
+# We set the `max_iterations` equal to 5000 for demonstration purposes.
+# <br>(This takes around 20 minutes on a Mac Book Pro with an Apple M2 Max chip).
 
-device = "cuda:0"
+device = "mps"  # 'mps', 'cpu', 'cuda:0'
 max_iterations = 5000
 
 train_config = TrainConfig(
@@ -44,16 +50,17 @@ train_config = TrainConfig(
     max_iterations=max_iterations,
 )
 
-# Next, we initialize the experiment config which puts together the config objects (`train_config` and `model_config`) which we defined above.
+# Next, we initialize the experiment config which puts together the config
+# objects (`train_config` and `model_config`) which we defined above.
 
 experiment_config = ExperimentConfig(
-    train_config=asdict(train_config), model_config=asdict(model_config)
+    train_config=asdict(train_config),
+    model_config=asdict(model_config),
+    normalization_factor=1.0,
 )
 
 # Now we can begin the training! <br>
 # Uncomment the next two lines to train the model.
 
-# +
 # from cellulus.train import train
 # train(experiment_config)
-# -

--- a/docs/examples/2d/03-infer.py
+++ b/docs/examples/2d/03-infer.py
@@ -71,7 +71,7 @@ model_config = ModelConfig(
 # Then, we specify inference-specific parameters such as the `device`, which indicates the actual device to run the inference on.
 # <br> The device could be set equal to `cuda:n` (where `n` is the index of the GPU, for e.g. `cuda:0`), `cpu` or `mps`.
 
-device = "mps"
+device = "cuda:0"
 
 # We initialize the `inference_config` which contains our `embeddings_dataset_config`, `segmentation_dataset_config` and `post_processed_dataset_config`.
 
@@ -93,7 +93,7 @@ experiment_config = ExperimentConfig(
 )
 
 # Now we are ready to start the inference!! <br>
-# (This takes around 7 minutes on a Mac Book Pro with an Apple M2 Max chip. To see the output of the cell below, remove the first line `io.capture_output()`).
+# (This takes around 7 minutes on a Mac Book Pro with an Apple M2 Max chip (i.e. `device = 'mps'`). To see the output of the cell below, remove the first line `io.capture_output()`).
 
 with io.capture_output() as captured:
     infer(experiment_config)
@@ -112,7 +112,7 @@ new_cmp = ListedColormap(np.load("cmap_60.npy"))
 # Change the value of `index` below to look at the raw image (left), x-offset (bottom-left), y-offset (bottom-right) and uncertainty of the embedding (top-right).
 
 # +
-index = 0
+index = 10
 
 f = zarr.open(name + ".zarr")
 ds = f["train/raw"]
@@ -135,8 +135,6 @@ visualize_2d(
 # As you can see the magnitude of the uncertainty of the embedding (top-right) is <i>low</i> for most of the foreground cells. <br> This enables extraction of the foreground, which is eventually clustered into individual instances.
 
 # +
-index = 0
-
 f = zarr.open(name + ".zarr")
 ds = f["train/raw"]
 ds2 = f["segmentation"]
@@ -145,8 +143,8 @@ ds3 = f["post_processed_segmentation"]
 visualize_2d(
     image,
     top_right=embedding[-1] < skimage.filters.threshold_otsu(embedding[-1]),
-    bottom_left=ds2[0, 0],
-    bottom_right=ds3[0, 0],
+    bottom_left=ds2[index, 0],
+    bottom_right=ds3[index, 0],
     top_right_label="THRESHOLDED F.G.",
     bottom_left_label="SEGMENTATION",
     bottom_right_label="POSTPROCESSED",
@@ -154,3 +152,4 @@ visualize_2d(
     bottom_left_cmap=new_cmp,
     bottom_right_cmap=new_cmp,
 )
+# -

--- a/docs/examples/2d/03-infer.py
+++ b/docs/examples/2d/03-infer.py
@@ -82,7 +82,7 @@ model_config = ModelConfig(
 # <br> The device could be set equal to `cuda:n` (where `n` is the index of
 # the GPU, for e.g. `cuda:0`), `cpu` or `mps`.
 
-device = "mps"  # "cuda:0", 'mps', 'cpu'
+device = "cuda:0"  # "cuda:0", 'mps', 'cpu'
 
 # We initialize the `inference_config` which contains our
 # `embeddings_dataset_config`, `segmentation_dataset_config` and
@@ -91,7 +91,6 @@ device = "mps"  # "cuda:0", 'mps', 'cpu'
 # would like the cell membrane to be segmented or the nucleus.
 
 post_processing = "nucleus"
-bandwidth = 15.0
 
 inference_config = InferenceConfig(
     dataset_config=asdict(dataset_config),
@@ -100,7 +99,6 @@ inference_config = InferenceConfig(
     post_processed_dataset_config=asdict(post_processed_dataset_config),
     post_processing=post_processing,
     device=device,
-    bandwidth=bandwidth,
 )
 
 # ## Initialize `experiment_config`
@@ -180,4 +178,3 @@ visualize_2d(
     bottom_left_cmap=new_cmp,
     bottom_right_cmap=new_cmp,
 )
-# -

--- a/docs/examples/2d/03-infer.py
+++ b/docs/examples/2d/03-infer.py
@@ -16,6 +16,7 @@ from cellulus.configs.inference_config import InferenceConfig
 from cellulus.configs.model_config import ModelConfig
 from cellulus.infer import infer
 from cellulus.utils.misc import visualize_2d
+from IPython.utils import io
 from matplotlib.colors import ListedColormap
 
 # ## Specify config values for datasets
@@ -79,6 +80,7 @@ inference_config = InferenceConfig(
     prediction_dataset_config=asdict(prediction_dataset_config),
     segmentation_dataset_config=asdict(segmentation_dataset_config),
     post_processed_dataset_config=asdict(post_processed_dataset_config),
+    post_processing="intensity",
     device=device,
 )
 
@@ -91,9 +93,10 @@ experiment_config = ExperimentConfig(
 )
 
 # Now we are ready to start the inference!! <br>
-# (This takes around 7 minutes on a Mac Book Pro with an Apple M2 Max chip).
+# (This takes around 7 minutes on a Mac Book Pro with an Apple M2 Max chip. To see the output of the cell below, remove the first line `io.capture_output()`).
 
-infer(experiment_config)
+with io.capture_output() as captured:
+    infer(experiment_config)
 
 # ## Inspect predictions
 
@@ -123,7 +126,7 @@ visualize_2d(
     top_right=embedding[-1],
     bottom_left=embedding[0],
     bottom_right=embedding[1],
-    top_right_label="STD_DEV",
+    top_right_label="UNCERTAINTY",
     bottom_left_label="OFFSET_X",
     bottom_right_label="OFFSET_Y",
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 template: home.html
-title: Title
+title: 
 social:
   cards_layout_options:
     title: Documentation for Cellulus

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ nav:
       - 01: examples/2d/01-data.py
       - 02: examples/2d/02-train.py
       - 03: examples/2d/03-infer.py
-  - API:
+  - API Reference:
       - Configs:
           - DatasetConfig: api/dataset_config.md
           - ExperimentConfig: api/experiment_config.md


### PR DESCRIPTION
- Make object size to be int type and bandwidth to be float type.
   1. Default value, if bandwidth is not specified, is `0.5*object_size` (b29dce73c9cba3645ad66ed9c370ebe806caf652)
   2. Note: for `tissuenet` dataset bandwidth should be set to `7` for reproducing the numbers in the paper
- Restore loss to be summed over all pixels instead of averaging and normalizing between `0` and `1` (955c2c482d54dc66017d38fe1e76f76655165107)
- Include `normalization_factor` config parameter  in `ExperimentConfig` (2e68fb51247d23d944852c4a9f2972e0df78affb)
- Include an alternate way of clustering (set `clustering = greedy`, default is `clustering = meanshift`) (a711b03caf1ea5efe79cff360e6c026c894c0e8e)
- Include an alternate way of post_processing (set `post_processing = cell` or `post_processing = nucleus`) based on whether a cell membrane needs to be segmented or a nucleus needs to be segmented (aa60a59d3c4c65cef50d5c1ee06b41452ead7577)
- Ignore using the scheduler (3f01fa5e1e0fb0123198c52924b74abb97ad6ab6)
- Best model weights are assessed (in an average sense) every `100` iterations by default (170abfd437effa98d4d793dbc2cd71ba0f19620c)
- Include `elastic_deform` as a parameter in `ZarrDataset` (582e1f180a6acdea04ce5fb0e2a153555b34066b)